### PR TITLE
add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Felt.coop <team@felt.social> (https://felt.social)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # felt-ui
+
+## license
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # felt-ui
 
-## license
+## license 🐦
 
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "license": "MIT"
+}


### PR DESCRIPTION
This adds the MIT license to the project. It initializes `package.json` with just the license property; in a followup PR, we'll flesh out the `package.json` metadata.

Do you know the best way to handle the copyright line? I just changed the year to 2021. Not sure what matters.

The 🐦 is a symbol I've been using in various projects to signal "permissive license".