### PR TITLE
add waiting animation component

### DIFF
--- a/src/lib/WaitingAnimation.svelte
+++ b/src/lib/WaitingAnimation.svelte
@@ -1,0 +1,33 @@
+<span class="one">•</span>
+<span class="two">•</span>
+<span class="three">•</span>
+
+<style>
+	span {
+		opacity: 0;
+		animation: dot 1.5s infinite;
+		color: var(--primary_color, #495499);
+	}
+
+	.one {
+		animation-delay: 0s;
+	}
+	.two {
+		animation-delay: 0.2s;
+	}
+	.three {
+		animation-delay: 0.3s;
+	}
+
+	@keyframes dot {
+		0% {
+			opacity: 0;
+		}
+		33% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+		}
+	}
+</style>


### PR DESCRIPTION
This adds the `WaitingAnimation.svelte` component that we wrote over a year ago for the mockup. Still looks sharp!

This line:

```css
color: var(--primary_color, #495499);
```

is aspirational: if any parent in the DOM specifies a `--primary_color` [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties), it'll use that, and if there is no such property, it falls back to a hardcoded blue. 

Here's a Svelte repl: https://svelte.dev/repl/a737cc455c7046e6a6f6faaca3695e77?version=3.36.0