### PR TITLE
rename WaitingAnimation to PendingAnimation and remove color style

### DIFF
--- a/src/lib/PendingAnimation.svelte
+++ b/src/lib/PendingAnimation.svelte
@@ -6,7 +6,6 @@
 	span {
 		opacity: 0;
 		animation: dot 1.5s infinite;
-		color: var(--primary_color, #495499);
 	}
 
 	.one {


### PR DESCRIPTION
This renames `WaitingAnimation.svelte` to `PendingAnimation.svelte` per our discussion in #6.

It also removes the line that adds a color, deferring completely to the parent.

Attached is a screenshot of the terminal workflow to prepare this PR. Note it uses `git mv` for better tool awareness (is this needed nowadays? I think sometimes things go awry if there are changes in a manually moved file):

(in case the aliases are confusing: `gs=git status`, `gd=git diff`, `gp=git push`, `gc=git commit` but I never remember)

![felt-ui-renaming-a-file-workflow](https://user-images.githubusercontent.com/2608646/113225271-11db1780-9242-11eb-9d3f-b9245adc08e4.png)
